### PR TITLE
Add Cinnamon support for notification actions and improve support for more types of email clients (e.g.: web apps)

### DIFF
--- a/Mailnag/plugins/libnotifyplugin.py
+++ b/Mailnag/plugins/libnotifyplugin.py
@@ -33,7 +33,6 @@ from typing import Any, Optional
 from gi.repository import Notify, Gio, Gtk
 from Mailnag.common.plugins import Plugin, HookTypes
 from Mailnag.common.i18n import _
-from Mailnag.common.subproc import start_subprocess
 from Mailnag.common.exceptions import InvalidOperationException
 from Mailnag.daemon.mails import Mail
 


### PR DESCRIPTION
Hi!

This very simple PR improves support for notification actions when an email is received, as partially reported in #5. It only affects the `libnotifyplugin.py` file.

### 1. Add Cinnamon as a supported desktop environment for notification actions

Right now, the notifications plugin is hard-coded to only enable notification actions if the `_is_gnome_environment()` function detects Gnome as the current desktop environment.

Given the actions are equally supported in Cinnamon, I've simply added the `cinnamon` string to the values that return `true`, and renamed the relevant functions to reflect this. E.g.: `_is_gnome_environment()` -> `_is_supported_environment()`.

Also extracted the supported environments as a list at the beginning of the file for easier readability and expandability if ever needed.

### 2. Launch email client properly by using `Gio.AppInfo.launch()` instead of `start_subprocess()`

For some reason, the current code is fetching the name of the executable that launches the email client with `Gio.AppInfo.get_executable(app_info)`, then trying to launch that executable through the low level function `start_subprocess(mailclient)`. Not only is this completely unnecessary, but is also a very fragile implementation and breaks compatibility with any email client that isn't a native app.

For instance, I'm using a Fastmail web app as my default email client (Mint's built-in web apps feature is awesome). This means the launch command associated with it is:
```bash
sh -c 'XAPP_FORCE_GTKWINDOW_ICON="web-fastmail" firefox --class WebApp-Fastmail3699 --name WebApp-Fastmail3699 --profile /home/MyUser/.local/share/ice/firefox/Fastmail3699 "https://betaapp.fastmail.com"'
```
With the current implementation, the "executable" that is fetched by the plugin is `sh`, which obviously means nothing happens when I click the notification.

By changing the code to use the more robust `Gio.AppInfo.launch(AppInfo)` function directly, the email client is launched correctly regardless of the app type. And as a bonus, we get to delete some code and remove an import 😬

I think it should be fairly straightforward to merge, but let me know if I should make any changes!